### PR TITLE
[#3][FIX] Fix buildout process by going back to old syntax for merges.

### DIFF
--- a/main/buildout.cfg
+++ b/main/buildout.cfg
@@ -1,6 +1,8 @@
 [buildout]
 parts =
+        clean_files
         odoo
+        merges
 
 versions = versions
 find-links = http://download.gna.org/pychart/
@@ -19,9 +21,6 @@ addons = local  local_modules
          git    https://github.com/OCA/geospatial       parts/geospatial        ${odoo:branch_name}
          git    https://github.com/OCA/web              parts/web               ${odoo:branch_name}
 
-merges = git    https://github.com/acsone/geospatial                parts/geospatial    8.0-migrate-from-7.0
-         git    https://github.com/acsone/odoo                      parts/odoo          8.0-fix-5616-ir_model_fields-from-fields
-         git    https://github.com/acsone/odoo                      parts/odoo          8.0-fix-use_symbol-c-in-sql-create
 
 with_devtools = False
 options.db_name = False
@@ -45,5 +44,47 @@ interpreter_name=python_odoo
 ; placeholder in case the variable is not set in frozen.cfg.
 ; do no change or set values here.
 revisions =
+
+[clean_files]
+recipe = cp.recipe.cmd
+
+clean_tree_acsone =
+             git clean -xfd
+             git remote rm acsone
+             git checkout ${odoo:branch_name}
+             git reset --hard origin/${odoo:branch_name}
+
+install_cmd =
+              if [ -d ${buildout:directory}/parts/odoo ]
+                then
+                  echo "Cleaning up odoo..."
+                  cd ${buildout:directory}/parts/odoo
+                  ${clean_files:clean_tree_acsone}
+              fi
+              if [ -d ${buildout:directory}/parts/geospatial ]
+                then
+                  echo "Cleaning up odoo..."
+                  cd ${buildout:directory}/parts/geospatial
+                  ${clean_files:clean_tree_acsone}
+              fi
+[merges]
+recipe = cp.recipe.cmd
+install_cmd =
+              echo "Patching odoo..."
+              cd ${buildout:directory}/parts/odoo
+              git remote add acsone https://github.com/acsone/odoo.git
+              git fetch acsone
+              git merge acsone/8.0-fix-5616-ir_model_fields-from-fields
+              git merge acsone/8.0-fix-use_symbol-c-in-sql-create
+
+              echo "Patching Geospatial..."
+              cd ${buildout:directory}/parts/geospatial
+              git remote add acsone https://github.com/acsone/geospatial.git
+              git fetch acsone
+              git merge ascone/8.0-migrate-from-7.0
+
+              cd ${buildout:directory}/..
+
+update_cmd = ${merges:install_cmd}
 
 [versions]

--- a/main/install.sh
+++ b/main/install.sh
@@ -4,7 +4,9 @@ PROJECT_HOME=`pwd`
 # Force to use the frozen configuration.
 # BUILDOUT_CFG=$PROJECT_HOME/frozen.cfg
 BUILDOUT_CFG=$PROJECT_HOME/frozen.cfg
-PARTS="odoo"
+# clean_files has to be called before odoo as it intends to reset the
+# external repository before merges and pulls.
+PARTS="clean_files odoo merges"
 
 # Prepare buildout environment
 /usr/bin/env python2 $PROJECT_HOME/bootstrap.py -c $BUILDOUT_CFG


### PR DESCRIPTION
Needed to move forward and not to only implement clean_files process but also to remove 1.9.0 merge syntax.
As a result of it, the old way to clean files and to merge had to be implemented.